### PR TITLE
add relatedOcrAttachment to InvoiceDetailsStream schema

### DIFF
--- a/tap_precoro/streams.py
+++ b/tap_precoro/streams.py
@@ -257,6 +257,7 @@ class InvoiceDetailsStream(PrecoroStream):
             "dataDocumentCustomFields", th.CustomType({"type": ["object", "array"]})
         ),
         th.Property("attachments", th.CustomType({"type": ["object", "array"]})),
+        th.Property("relatedOcrAttachment", th.CustomType({"type": ["object", "array", "null"]})),
         th.Property("allocatedInvoice", th.CustomType({"type": ["object", "array"]})),
         th.Property("contracts", th.CustomType({"type": ["object", "array"]})),
         th.Property("isBudgetOverLimit", th.BooleanType),


### PR DESCRIPTION
## What
Add the `relatedOcrAttachment` property to the `InvoiceDetailsStream` schema in `tap_precoro/streams.py`.

## Why
The CompanyShop (SFTP) flow needs the `relatedOcrAttachment` field from invoice details to be extracted by the tap. Without it in the schema, the field is dropped from the stream output.

## Changes
- `tap_precoro/streams.py`: add `relatedOcrAttachment` as a nullable object/array property on `InvoiceDetailsStream`.

## Notes
Typed as `["object", "array", "null"]` to match the surrounding attachment-related properties and allow null when no OCR attachment is present.