### PR TITLE
Skip quarantined invoices

### DIFF
--- a/tap_precoro/client.py
+++ b/tap_precoro/client.py
@@ -4,6 +4,9 @@ import requests
 import json
 import hmac
 import hashlib
+import csv
+import os
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, Optional, Union, List, Iterable
 import time
@@ -193,12 +196,64 @@ class AccountSetupMixin:
 class ExternalIdTwoPassMixin:
     """Mixin for streams that fetch incremental records first, then records without externalId; yields deduplicated results."""
 
+    _QUARANTINE_FIELDS = ["idn", "issueDate", "dueDate", "supplierId", "currency", "items"]
+    _DAILY_RETRY_HOURS = 24
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.config.get("fetch_unexported", False):
             start_date = self.config.get("start_date")
             if not start_date or start_date == "2000-01-01T00:00:00Z":
                 raise Exception("Please set start_date param if you want to use fetch_unexported")
+
+    def _snapshot_dir(self) -> str:
+        return os.path.join(os.environ.get("ROOT_DIR", "."), "snapshots")
+
+    def _load_quarantine(self) -> dict:
+        """Returns {str(precoro_id): row_dict} from exact_quarantine.csv."""
+        path = os.path.join(self._snapshot_dir(), "exact_quarantine.csv")
+        if not os.path.exists(path):
+            return {}
+        with open(path, newline="") as f:
+            return {r["precoro_id"]: r for r in csv.DictReader(f)}
+
+    def _load_hashes(self) -> dict:
+        """Returns {str(precoro_id): data_hash} from exact_export_hashes.csv."""
+        path = os.path.join(self._snapshot_dir(), "exact_export_hashes.csv")
+        if not os.path.exists(path):
+            return {}
+        with open(path, newline="") as f:
+            return {r["precoro_id"]: r["data_hash"] for r in csv.DictReader(f)}
+
+    def _save_hashes(self, hashes: dict) -> None:
+        os.makedirs(self._snapshot_dir(), exist_ok=True)
+        path = os.path.join(self._snapshot_dir(), "exact_export_hashes.csv")
+        with open(path, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=["precoro_id", "data_hash"])
+            w.writeheader()
+            w.writerows({"precoro_id": k, "data_hash": v} for k, v in hashes.items())
+
+    def _hash_record(self, record: dict) -> str:
+        material = {k: record.get(k) for k in self._QUARANTINE_FIELDS}
+        return hashlib.md5(
+            json.dumps(material, sort_keys=True, default=str).encode()
+        ).hexdigest()
+
+    def _should_skip(self, record: dict, quarantine: dict, hashes: dict) -> bool:
+        """True = skip this record in the second pass (quarantined, data unchanged, retry window not elapsed)."""
+        pid = str(record["id"])
+        if pid not in quarantine:
+            return False
+
+        current_hash = self._hash_record(record)
+        if current_hash != hashes.get(pid, ""):
+            return False  # data changed → retry
+
+        last_failed = datetime.fromisoformat(quarantine[pid]["last_failed"])
+        if datetime.utcnow() - last_failed.replace(tzinfo=None) >= timedelta(hours=self._DAILY_RETRY_HOURS):
+            return False  # daily retry window elapsed
+
+        return True
 
     def request_records(self, context: Optional[dict]) -> Iterable[dict]:
         seen_ids = set()
@@ -210,15 +265,25 @@ class ExternalIdTwoPassMixin:
         if not self.config.get("fetch_unexported", False):
             return
 
+        quarantine = self._load_quarantine()
+        hashes = self._load_hashes()
+
         self._fetch_no_external_only = True
         self.page = 1
-        pass2_count = 0
+        pass2_count = skipped_count = 0
         try:
             for record in super().request_records(context):
                 if record["id"] in seen_ids:
                     continue
+                if self._should_skip(record, quarantine, hashes):
+                    skipped_count += 1
+                    continue
+                hashes[str(record["id"])] = self._hash_record(record)
                 pass2_count += 1
                 yield record
         finally:
             self._fetch_no_external_only = False
-        self.logger.info(f"{self.name.capitalize()} without externalId: {pass2_count}")
+            self._save_hashes(hashes)
+        self.logger.info(
+            f"{self.name.capitalize()} without externalId: {pass2_count} yielded, {skipped_count} quarantined/skipped"
+        )

--- a/tap_precoro/streams.py
+++ b/tap_precoro/streams.py
@@ -1,7 +1,10 @@
 """Stream type classes for tap-precoro."""
 
+import time
 from datetime import datetime
 from typing import Optional, Iterable
+
+import requests
 from singer_sdk import typing as th  # JSON Schema typing helpers
 from pendulum import parse
 
@@ -273,6 +276,7 @@ class SuppliersStream(ExternalIdTwoPassMixin, PrecoroStream):
         th.Property("name", th.StringType),
         th.Property("createDate", th.DateTimeType),
         th.Property("updateDate", th.DateTimeType),
+        th.Property("approvalDate", th.DateTimeType),
         th.Property("legalAddress", th.StringType),
         th.Property("currency", th.StringType),
         th.Property("autoSendPOSupplier", th.BooleanType),
@@ -306,10 +310,13 @@ class SuppliersStream(ExternalIdTwoPassMixin, PrecoroStream):
         th.Property("enable", th.BooleanType),
         th.Property("isMarketUpdatable", th.BooleanType),
         th.Property("qboId", th.StringType),
+        th.Property("netSuiteId", th.CustomType({"type": ["number", "string"]})),
+        th.Property("integrationStatus", th.CustomType({"type": ["object", "string", "array", "number"]})),
         th.Property("externalId", th.CustomType({"type": ["number", "string"]})),
         th.Property("xeroId", th.StringType),
         th.Property("marketSupplier", th.ObjectType(
             th.Property("id", th.IntegerType),    
+            th.Property("minimumSum", th.CustomType({"type": ["number", "string"]})),
         )),
         th.Property("enableMarketSupplier", th.BooleanType),
         th.Property("creditBalanceSums", th.CustomType({"type": ["object", "array"]})),
@@ -327,8 +334,10 @@ class SuppliersStream(ExternalIdTwoPassMixin, PrecoroStream):
                     th.Property("prepaymentPercent", th.NumberType),
                     th.Property("postpaymentPercent", th.NumberType),
                     th.Property("creditPeriodDays", th.NumberType),
+                    th.Property("termsDueDateAfterInvoicing", th.NumberType),
                     th.Property("paymentType", th.NumberType),
                     th.Property("enable", th.BooleanType),
+                    th.Property("externalId", th.CustomType({"type": ["number", "string"]})),
                 )
             )),
         )),
@@ -343,12 +352,68 @@ class SuppliersStream(ExternalIdTwoPassMixin, PrecoroStream):
            th.Property("data", th.ArrayType(th.CustomType({"type": ["object", "array", "string"]}))), 
         )),
         th.Property("supplierRegistration", th.CustomType({"type": ["object", "array", "string"]})),
+        th.Property("supplierRegistrations", th.CustomType({"type": ["object", "array"]})),
+        th.Property("attachments", th.CustomType({"type": ["object", "array"]})),
+        th.Property("marketAttachments", th.CustomType({"type": ["object", "array"]})),
         th.Property("approvalInfo", th.ObjectType(
             th.Property("canApprove", th.BooleanType),
             th.Property("canReject", th.BooleanType),
+            th.Property("canEditSupplierByInRevision", th.BooleanType),
         )),
         th.Property("dataSupplierCustomFields", th.CustomType({"type": ["object", "string"]})),
+        th.Property("propsVisibility", th.CustomType({"type": ["object", "array"]})),
+        th.Property("supplierTaxDefaultOptions", th.CustomType({"type": ["object", "array"]})),
+        th.Property("supplierICFDefaultOptions", th.CustomType({"type": ["object", "array"]})),
+        th.Property("supplierDCFDefaultOptions", th.CustomType({"type": ["object", "array"]})),
+        th.Property("supplierCustomFieldOptionValues", th.CustomType({"type": ["object", "array"]})),
+        th.Property("supplierToleranceLimitsSetup", th.CustomType({"type": ["object", "array"]})),
+        th.Property("showApprovingWay", th.CustomType({"type": ["object", "array", "string"]})),
+        th.Property("showApprovalReviewers", th.CustomType({"type": ["object", "array", "string"]})),
+        th.Property("substitute", th.CustomType({"type": ["object", "array", "string"]})),
+        th.Property("supplierLegalEntities", th.CustomType({"type": ["object", "array"]})),
+        th.Property("voters", th.CustomType({"type": ["object", "array"]})),
+        th.Property("isEnabledApproval", th.BooleanType),
+        th.Property("accessToDocuments", th.CustomType({"type": ["object", "array"]})),
+        th.Property("isPunchoutSupplier", th.BooleanType),
+        th.Property("isAllAccessLegalEntity", th.BooleanType),
     ).to_dict()
+
+    def _fetch_supplier_details(self, supplier_id) -> dict:
+        headers = dict(self.http_headers)
+        headers["X-AUTH-TOKEN"] = self.config.get("auth_token")
+
+        time.sleep(1)
+
+        response = self.requests_session.get(
+            f"{self.url_base}/suppliers/{supplier_id}",
+            headers=headers,
+        )
+        self.validate_response(response)
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
+    def request_records(self, context: Optional[dict]) -> Iterable[dict]:
+        for supplier in super().request_records(context):
+            supplier_id = supplier.get("id")
+
+            try:
+                supplier_details = self._fetch_supplier_details(supplier_id)
+            except (requests.RequestException, ValueError) as exc:
+                self.logger.warning(
+                    "Failed to fetch supplier details for id %s: %s",
+                    supplier_id,
+                    exc,
+                )
+                yield supplier
+                continue
+
+            if not supplier_details:
+                yield supplier
+                continue
+
+            supplier_details.setdefault("id", supplier_id)
+            supplier_details.setdefault("updateDate", supplier.get("updateDate"))
+            yield supplier_details
 
     def get_url_params(self, context, next_page_token):
         params = super().get_url_params(context, next_page_token)

--- a/tap_precoro/streams.py
+++ b/tap_precoro/streams.py
@@ -384,11 +384,19 @@ class SuppliersStream(ExternalIdTwoPassMixin, PrecoroStream):
 
         time.sleep(1)
 
+        started_at = time.perf_counter()
+
         response = self.requests_session.get(
             f"{self.url_base}/suppliers/{supplier_id}",
             headers=headers,
         )
         self.validate_response(response)
+        self.logger.info(
+            "Supplier details request endpoint=/suppliers/%s status=%s duration=%.3fs",
+            supplier_id,
+            response.status_code,
+            time.perf_counter() - started_at,
+        )
         payload = response.json()
         return payload if isinstance(payload, dict) else {}
 

--- a/tap_precoro/streams.py
+++ b/tap_precoro/streams.py
@@ -257,7 +257,7 @@ class InvoiceDetailsStream(PrecoroStream):
             "dataDocumentCustomFields", th.CustomType({"type": ["object", "array"]})
         ),
         th.Property("attachments", th.CustomType({"type": ["object", "array"]})),
-        th.Property("relatedOcrAttachment", th.CustomType({"type": ["object", "array", "null"]})),
+        th.Property("relatedOcrAttachment", th.CustomType({"type": ["object", "array"]})),
         th.Property("allocatedInvoice", th.CustomType({"type": ["object", "array"]})),
         th.Property("contracts", th.CustomType({"type": ["object", "array"]})),
         th.Property("isBudgetOverLimit", th.BooleanType),


### PR DESCRIPTION
This PR add skipping for quarantined invoices, because when invoices fail for permanent reasons, they get retried forever. This burns Exact Online's daily API quota, after which every call that day fails with 429 (Too Many Requests error).