### PR TITLE
Feature/document import with disable connector

### DIFF
--- a/tap_precoro/streams.py
+++ b/tap_precoro/streams.py
@@ -1,7 +1,10 @@
 """Stream type classes for tap-precoro."""
 
+import time
 from datetime import datetime
 from typing import Optional, Iterable
+
+import requests
 from singer_sdk import typing as th  # JSON Schema typing helpers
 from pendulum import parse
 
@@ -273,6 +276,7 @@ class SuppliersStream(ExternalIdTwoPassMixin, PrecoroStream):
         th.Property("name", th.StringType),
         th.Property("createDate", th.DateTimeType),
         th.Property("updateDate", th.DateTimeType),
+        th.Property("approvalDate", th.DateTimeType),
         th.Property("legalAddress", th.StringType),
         th.Property("currency", th.StringType),
         th.Property("autoSendPOSupplier", th.BooleanType),
@@ -306,10 +310,13 @@ class SuppliersStream(ExternalIdTwoPassMixin, PrecoroStream):
         th.Property("enable", th.BooleanType),
         th.Property("isMarketUpdatable", th.BooleanType),
         th.Property("qboId", th.StringType),
+        th.Property("netSuiteId", th.CustomType({"type": ["number", "string"]})),
+        th.Property("integrationStatus", th.CustomType({"type": ["object", "string", "array", "number"]})),
         th.Property("externalId", th.CustomType({"type": ["number", "string"]})),
         th.Property("xeroId", th.StringType),
         th.Property("marketSupplier", th.ObjectType(
             th.Property("id", th.IntegerType),    
+            th.Property("minimumSum", th.CustomType({"type": ["number", "string"]})),
         )),
         th.Property("enableMarketSupplier", th.BooleanType),
         th.Property("creditBalanceSums", th.CustomType({"type": ["object", "array"]})),
@@ -327,8 +334,10 @@ class SuppliersStream(ExternalIdTwoPassMixin, PrecoroStream):
                     th.Property("prepaymentPercent", th.NumberType),
                     th.Property("postpaymentPercent", th.NumberType),
                     th.Property("creditPeriodDays", th.NumberType),
+                    th.Property("termsDueDateAfterInvoicing", th.NumberType),
                     th.Property("paymentType", th.NumberType),
                     th.Property("enable", th.BooleanType),
+                    th.Property("externalId", th.CustomType({"type": ["number", "string"]})),
                 )
             )),
         )),
@@ -343,12 +352,68 @@ class SuppliersStream(ExternalIdTwoPassMixin, PrecoroStream):
            th.Property("data", th.ArrayType(th.CustomType({"type": ["object", "array", "string"]}))), 
         )),
         th.Property("supplierRegistration", th.CustomType({"type": ["object", "array", "string"]})),
+        th.Property("supplierRegistrations", th.CustomType({"type": ["object", "array"]})),
+        th.Property("attachments", th.CustomType({"type": ["object", "array"]})),
+        th.Property("marketAttachments", th.CustomType({"type": ["object", "array"]})),
         th.Property("approvalInfo", th.ObjectType(
             th.Property("canApprove", th.BooleanType),
             th.Property("canReject", th.BooleanType),
+            th.Property("canEditSupplierByInRevision", th.BooleanType),
         )),
         th.Property("dataSupplierCustomFields", th.CustomType({"type": ["object", "string"]})),
+        th.Property("propsVisibility", th.CustomType({"type": ["object", "array"]})),
+        th.Property("supplierTaxDefaultOptions", th.CustomType({"type": ["object", "array"]})),
+        th.Property("supplierICFDefaultOptions", th.CustomType({"type": ["object", "array"]})),
+        th.Property("supplierDCFDefaultOptions", th.CustomType({"type": ["object", "array"]})),
+        th.Property("supplierCustomFieldOptionValues", th.CustomType({"type": ["object", "array"]})),
+        th.Property("supplierToleranceLimitsSetup", th.CustomType({"type": ["object", "array"]})),
+        th.Property("showApprovingWay", th.CustomType({"type": ["object", "array", "string"]})),
+        th.Property("showApprovalReviewers", th.CustomType({"type": ["object", "array", "string"]})),
+        th.Property("substitute", th.CustomType({"type": ["object", "array", "string"]})),
+        th.Property("supplierLegalEntities", th.CustomType({"type": ["object", "array"]})),
+        th.Property("voters", th.CustomType({"type": ["object", "array"]})),
+        th.Property("isEnabledApproval", th.BooleanType),
+        th.Property("accessToDocuments", th.CustomType({"type": ["object", "array"]})),
+        th.Property("isPunchoutSupplier", th.BooleanType),
+        th.Property("isAllAccessLegalEntity", th.BooleanType),
     ).to_dict()
+
+    def _fetch_supplier_details(self, supplier_id) -> dict:
+        headers = dict(self.http_headers)
+        headers["X-AUTH-TOKEN"] = self.config.get("auth_token")
+
+        time.sleep(1)
+
+        response = self.requests_session.get(
+            f"{self.url_base}/suppliers/{supplier_id}",
+            headers=headers,
+        )
+        self.validate_response(response)
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
+    def request_records(self, context: Optional[dict]) -> Iterable[dict]:
+        for supplier in super().request_records(context):
+            supplier_id = supplier.get("id")
+
+            try:
+                supplier_details = self._fetch_supplier_details(supplier_id)
+            except (requests.RequestException, ValueError) as exc:
+                self.logger.warning(
+                    "Failed to fetch supplier details for id %s: %s",
+                    supplier_id,
+                    exc,
+                )
+                yield supplier
+                continue
+
+            if not supplier_details:
+                yield supplier
+                continue
+
+            supplier_details.setdefault("id", supplier_id)
+            supplier_details.setdefault("updateDate", supplier.get("updateDate"))
+            yield supplier_details
 
     def get_url_params(self, context, next_page_token):
         params = super().get_url_params(context, next_page_token)

--- a/tap_precoro/streams.py
+++ b/tap_precoro/streams.py
@@ -384,11 +384,19 @@ class SuppliersStream(ExternalIdTwoPassMixin, PrecoroStream):
 
         time.sleep(1)
 
+        started_at = time.perf_counter()
+
         response = self.requests_session.get(
             f"{self.url_base}/suppliers/{supplier_id}",
             headers=headers,
         )
         self.validate_response(response)
+        self.logger.info(
+            "Supplier details request endpoint=/suppliers/%s status=%s duration=%.3fs",
+            supplier_id,
+            response.status_code,
+            time.perf_counter() - started_at,
+        )
         payload = response.json()
         return payload if isinstance(payload, dict) else {}
 

--- a/tap_precoro/streams.py
+++ b/tap_precoro/streams.py
@@ -257,7 +257,7 @@ class InvoiceDetailsStream(PrecoroStream):
             "dataDocumentCustomFields", th.CustomType({"type": ["object", "array"]})
         ),
         th.Property("attachments", th.CustomType({"type": ["object", "array"]})),
-        th.Property("relatedOcrAttachment", th.CustomType({"type": ["object", "array", "null"]})),
+        th.Property("relatedOcrAttachment", th.CustomType({"type": ["object", "array"]})),
         th.Property("allocatedInvoice", th.CustomType({"type": ["object", "array"]})),
         th.Property("contracts", th.CustomType({"type": ["object", "array"]})),
         th.Property("isBudgetOverLimit", th.BooleanType),

--- a/tap_precoro/streams.py
+++ b/tap_precoro/streams.py
@@ -10,6 +10,10 @@ from pendulum import parse
 
 from tap_precoro.client import PrecoroStream, ExternalIdTwoPassMixin, AccountSetupMixin
 
+# Precoro integrationStatus value meaning the document is waiting on a disabled/offline
+# connector (handled by the hotglue-webhook path now), so the polling job must skip it.
+INTEGRATION_STATUS_WAITING_FOR_CONNECTOR = 8
+
 
 class TaxesStream(PrecoroStream):
     """Define custom stream."""
@@ -126,7 +130,15 @@ class InvoicesStream(ExternalIdTwoPassMixin, TransactionsStream):
     
     def post_process(self, row, context):
         row = super().post_process(row, context)
-        
+
+        # Skip invoices waiting on a disabled connector: the hotglue-webhook now
+        # handles those once the connector comes back, so the polling job must not re-pull them.
+        if row.get("integrationStatus") == INTEGRATION_STATUS_WAITING_FOR_CONNECTOR:
+            self.logger.info(
+                f"Invoice with id {row['id']} skipped because integrationStatus is 'Waiting for Connector' (8)"
+            )
+            return None
+
         # Filter by perantIdn: only keep invoices where there are no parentIdn
         parent_idn = row.get("parentIdn")
         if parent_idn:
@@ -613,6 +625,14 @@ class CreditNotesStream(ExternalIdTwoPassMixin, TransactionsStream):
 
     def post_process(self, row, context):
         row = super().post_process(row, context)
+
+        # Skip credit notes waiting on a disabled connector: the hotglue-webhook now
+        # handles those once the connector comes back, so the polling job must not re-pull them.
+        if row.get("integrationStatus") == INTEGRATION_STATUS_WAITING_FOR_CONNECTOR:
+            self.logger.info(
+                f"Credit note with id {row['id']} skipped because integrationStatus is 'Waiting for Connector' (8)"
+            )
+            return None
 
         if self.export_conditions is None:
             export_conditions = []


### PR DESCRIPTION
This PR adds logic to skip invoices and credit notes with integrationStatus = 8 (Waiting for Connector) in InvoicesStream and CreditNotesStream, since these are now handled by the disabled-connector webhook and should not be re-pulled by the polling job.